### PR TITLE
Remove dynamic CSS feature

### DIFF
--- a/css/default.css
+++ b/css/default.css
@@ -12,7 +12,7 @@ h1, h4, h5, h6, .header-sans {
 h2, h3, blockquote,
 .serif, .dropdown-header,
 .title-small-screen, .header-serif, .title, .navbar-title {
-  font-family: 'Freight Text Pro', Georgia, Times, serif;
+  font-family: Georgia, Times, serif;
   font-weight: bold;
 }
 

--- a/loader.js
+++ b/loader.js
@@ -44,7 +44,6 @@ llab.loaded = {};  // keys are true if that script file is loaded
 llab.paths  = {};
 llab.paths.stage_complete_functions = [];
 llab.paths.scripts = [];  // holds the scripts to load, in stages below
-llab.paths.css_files = [];
 llab.rootURL = "";  // to be overridden in llab-config.js
 llab.install_directory = "";  // to be overridden in llab-config.js
 
@@ -63,19 +62,6 @@ llab.altFiles.syntax_highlights_css = "lib/highlightjs/styles/tomorrow-night-blu
 // Math / LaTeX rendering
 llab.altFiles.math_katex_js = "lib/katex.min.js";
 llab.altFiles.math_katex_css = "css/katex.min.css";
-
-
-
-/////////////////////////
-// reference your custom CSS files, from within llab install directory.
-// Multiple CSS files is fine, include a separate push for each
-llab.paths.css_files.push('lib/bootstrap/dist/css/bootstrap.min.css');
-llab.paths.css_files.push('lib/bootstrap/dist/css/bootstrap-theme.min.css');
-// llab.paths.css_files.push('css/brainstorm.css');
-// llab.paths.css_files.push('css/matchsequence.css');
-llab.paths.css_files.push('css/default.css');
-
-
 
 ///////////////////////// pre stage 0
 llab.paths.defaults_file = "script/defaults.js";
@@ -199,13 +185,6 @@ llab.initialSetup = function() {
 
     function loadScriptsAndLinks(stage_num) {
         var i, tag;
-
-        // load css files
-        while (llab.paths.css_files.length != 0) {
-            tag = llab.loader.getTag("link", llab.paths.css_files.shift(), "text/css");
-            tag.rel = "stylesheet";
-            headElement.appendChild(tag);
-        }
 
         // load scripts
         llab.paths.scripts[stage_num].forEach(function(scriptfile) {

--- a/loader.js
+++ b/loader.js
@@ -64,6 +64,19 @@ llab.altFiles.syntax_highlights_css = "lib/highlightjs/styles/tomorrow-night-blu
 llab.altFiles.math_katex_js = "lib/katex.min.js";
 llab.altFiles.math_katex_css = "css/katex.min.css";
 
+
+
+/////////////////////////
+// reference your custom CSS files, from within llab install directory.
+// Multiple CSS files is fine, include a separate push for each
+llab.paths.css_files.push('lib/bootstrap/dist/css/bootstrap.min.css');
+llab.paths.css_files.push('lib/bootstrap/dist/css/bootstrap-theme.min.css');
+// llab.paths.css_files.push('css/brainstorm.css');
+// llab.paths.css_files.push('css/matchsequence.css');
+llab.paths.css_files.push('css/default.css');
+
+
+
 ///////////////////////// pre stage 0
 llab.paths.defaults_file = "script/defaults.js";
 
@@ -186,6 +199,13 @@ llab.initialSetup = function() {
 
     function loadScriptsAndLinks(stage_num) {
         var i, tag;
+
+        // load css files
+        while (llab.paths.css_files.length != 0) {
+            tag = llab.loader.getTag("link", llab.paths.css_files.shift(), "text/css");
+            tag.rel = "stylesheet";
+            headElement.appendChild(tag);
+        }
 
         // load scripts
         llab.paths.scripts[stage_num].forEach(function(scriptfile) {

--- a/loader.js
+++ b/loader.js
@@ -44,6 +44,7 @@ llab.loaded = {};  // keys are true if that script file is loaded
 llab.paths  = {};
 llab.paths.stage_complete_functions = [];
 llab.paths.scripts = [];  // holds the scripts to load, in stages below
+llab.paths.css_files = [];
 llab.rootURL = "";  // to be overridden in llab-config.js
 llab.install_directory = "";  // to be overridden in llab-config.js
 

--- a/script/curriculum.js
+++ b/script/curriculum.js
@@ -321,49 +321,49 @@ llab.addFrame = function () {
 llab.setupTitle = function () {
     var titleText;
     // TODO: rename / refactor location
-    $(document.head).append('<meta name="viewport" content="width=device-width, initial-scale=1">');
+//    $(document.head).append('<meta name="viewport" content="width=device-width, initial-scale=1">');
 
     if (llab.titleSet) {
         return;
     }
-
     // Create .full before adding stuff.
-    if ($(FULL).length === 0) {
-        // TODO: Fix this line to be generic.
-        $(document.body).wrapInner('<div class="llab-full"></div>');
-    }
+    // if ($(FULL).length === 0) {
+    //     debugger;
+    //     // TODO: Fix this line to be generic.
+    //     $(document.body).wrapInner('<div class="llab-full"></div>');
+    // }
 
     // Work around when things are oddly loaded...
-    if ($(llab.selectors.NAVSELECT).length !== 0) {
-        $(llab.selectors.NAVSELECT).remove();
-    }
+    // if ($(llab.selectors.NAVSELECT).length !== 0) {
+    //     $(llab.selectors.NAVSELECT).remove();
+    // }
 
     // Create the header section and nav buttons
-    llab.createTitleNav();
+//    llab.createTitleNav();
 
     // create Title tag, yo
     titleText = llab.getQueryParameter("title");
     if (titleText !== '') {
-        document.title = titleText;
+     //   document.title = titleText;
     }
 
     // Set the header title to the page title.
     titleText = document.title;
     if (titleText) {
         // FIXME this needs to be a selector
-        $('.navbar-title').html(titleText);
-        $('.title-small-screen').html(titleText);
+//        $('.navbar-title').html(titleText);
+ //       $('.title-small-screen').html(titleText);
     }
 
     // Clean up document title if it contains HTML
-    document.title = $(".navbar-title").text();
+//    document.title = $(".navbar-title").text();
     // Special Case for Snap! in titles.
-    document.title = document.title.replace('snap', 'Snap!');
+  //  document.title = document.title.replace('snap', 'Snap!');
 
-    $(document.body).css('padding-top', $(llab.selectors.NAVSELECT).height() + 10);
-    document.body.onresize = function(event) {
-        $(document.body).css('padding-top', $(llab.selectors.NAVSELECT).height() + 10);
-    };
+    // $(document.body).css('padding-top', $(llab.selectors.NAVSELECT).height() + 10);
+    // document.body.onresize = function(event) {
+    //     $(document.body).css('padding-top', $(llab.selectors.NAVSELECT).height() + 10);
+    // };
 
     llab.titleSet = true;
 };
@@ -499,10 +499,10 @@ llab.setButtonURLs = function() {
 
     var buttonsExist = forward.length !== 0 && back.length !== 0;
 
-    if (!buttonsExist & $(llab.selectors.NAVSELECT) !== 0) {
-        // freshly minted buttons. MMM, tasty!
-        llab.createTitleNav();
-    }
+    // if (!buttonsExist & $(llab.selectors.NAVSELECT) !== 0) {
+    //     // freshly minted buttons. MMM, tasty!
+    //     llab.createTitleNav();
+    // }
 
     forward = $('.forwardbutton');
     back    = $('.backbutton');
@@ -560,20 +560,20 @@ llab.addFeedback = function(title, topic, course) {
                           .replace(/courseRep/g, encodeURIComponent(course))
                           .replace(/urlRep/g, encodeURIComponent(document.URL));
 
-    var button = $(document.createElement('button')).attr(
-            {   'class': 'btn btn-primary btn-xs feedback-button',
-                'type': 'button',
-                'data-toggle': "collapse",
-                'data-target': "#fdbk" }).text('Feedback'),
-        innerDiv = $(document.createElement('div')).attr({
-                'id': "fdbk",
-                'class': "collapse feedback-panel panel panel-primary"
-            }),
-        feedback = $(document.createElement('div')).attr(
-            {'class' : 'page-feedback'}).append(button, innerDiv);
+    // var button = $(document.createElement('button')).attr(
+    //         {   'class': 'btn btn-primary btn-xs feedback-button',
+    //             'type': 'button',
+    //             'data-toggle': "collapse",
+    //             'data-target': "#fdbk" }).text('Feedback'),
+    //     innerDiv = $(document.createElement('div')).attr({
+    //             'id': "fdbk",
+    //             'class': "collapse feedback-panel panel panel-primary"
+        //         }),
+    //     feedback = $(document.createElement('div')).attr(
+    //         {'class' : 'page-feedback'}).append(button, innerDiv);
 
     // Delay inserting a frame until the button is clicked.
-    button.click('click', function (event) {
+    $(".feedback-button").click('click', function (event) {
         if ($('#feedback-frame').length === 0) {
             var frame = $(document.createElement('iframe')).attr(
             {
@@ -586,7 +586,7 @@ llab.addFeedback = function(title, topic, course) {
             $('#fdbk').append(frame);
         }
     });
-    $(document.body).append(feedback);
+//    $(document.body).append(feedback);
 };
 
 /**

--- a/script/curriculum.js
+++ b/script/curriculum.js
@@ -330,7 +330,8 @@ llab.setupTitle = function () {
     // Create .full before adding stuff.
     if ($(FULL).length === 0) {
         // TODO: Fix this line to be generic.
-        $(document.body).wrapInner('<div class="llab-full"></div>');
+        if ($(llab.selectors.FULL) == 0)
+            $(document.body).wrapInner('<div class="llab-full"></div>');
     }
 
     // Work around when things are oddly loaded...
@@ -586,6 +587,8 @@ llab.addFeedback = function(title, topic, course) {
             $('#fdbk').append(frame);
         }
     });
+    if ($("page-feedback") !== 0)
+        $("page-feedback").remove();
     $(document.body).append(feedback);
 };
 

--- a/script/curriculum.js
+++ b/script/curriculum.js
@@ -321,7 +321,7 @@ llab.addFrame = function () {
 llab.setupTitle = function () {
     var titleText;
     // TODO: rename / refactor location
-//    $(document.head).append('<meta name="viewport" content="width=device-width, initial-scale=1">');
+    $(document.head).append('<meta name="viewport" content="width=device-width, initial-scale=1">');
 
     if (llab.titleSet) {
         return;
@@ -333,37 +333,37 @@ llab.setupTitle = function () {
             $(document.body).wrapInner('<div class="llab-full"></div>');
     }
 
-    // Work around when things are oddly loaded...
-    // if ($(llab.selectors.NAVSELECT).length !== 0) {
-    //     $(llab.selectors.NAVSELECT).remove();
-    // }
+    // If NAVSELET was inlined, remove it and re-add it.
+    if ($(llab.selectors.NAVSELECT).length !== 0) {
+        $(llab.selectors.NAVSELECT).remove();
+    }
 
     // Create the header section and nav buttons
-//    llab.createTitleNav();
+    llab.createTitleNav();
 
     // create Title tag, yo
     titleText = llab.getQueryParameter("title");
     if (titleText !== '') {
-     //   document.title = titleText;
+        document.title = titleText;
     }
 
     // Set the header title to the page title.
     titleText = document.title;
     if (titleText) {
         // FIXME this needs to be a selector
-//        $('.navbar-title').html(titleText);
- //       $('.title-small-screen').html(titleText);
+        $('.navbar-title').html(titleText);
+        $('.title-small-screen').html(titleText);
     }
 
     // Clean up document title if it contains HTML
-//    document.title = $(".navbar-title").text();
+    document.title = $(".navbar-title").text();
     // Special Case for Snap! in titles.
-  //  document.title = document.title.replace('snap', 'Snap!');
+    document.title = document.title.replace('snap', 'Snap!');
 
-    // $(document.body).css('padding-top', $(llab.selectors.NAVSELECT).height() + 10);
-    // document.body.onresize = function(event) {
-    //     $(document.body).css('padding-top', $(llab.selectors.NAVSELECT).height() + 10);
-    // };
+    $(document.body).css('padding-top', $(llab.selectors.NAVSELECT).height() + 10);
+    document.body.onresize = function(event) {
+        $(document.body).css('padding-top', $(llab.selectors.NAVSELECT).height() + 10);
+    };
 
     llab.titleSet = true;
 };
@@ -499,10 +499,10 @@ llab.setButtonURLs = function() {
 
     var buttonsExist = forward.length !== 0 && back.length !== 0;
 
-    // if (!buttonsExist & $(llab.selectors.NAVSELECT) !== 0) {
-    //     // freshly minted buttons. MMM, tasty!
-    //     llab.createTitleNav();
-    // }
+    if (!buttonsExist & $(llab.selectors.NAVSELECT) !== 0) {
+        // freshly minted buttons. MMM, tasty!
+        llab.createTitleNav();
+    }
 
     forward = $('.forwardbutton');
     back    = $('.backbutton');
@@ -573,7 +573,7 @@ llab.addFeedback = function(title, topic, course) {
             {'class' : 'page-feedback'}).append(button, innerDiv);
 
     // Delay inserting a frame until the button is clicked.
-    $(".feedback-button").click('click', function (event) {
+    button.click('click', function (event) {
         if ($('#feedback-frame').length === 0) {
             var frame = $(document.createElement('iframe')).attr(
             {


### PR DESCRIPTION
Right now, bjc websites based on llab suffer from very bad Flash of Unstyled Content (FOUC), The reason for this
has multiple causes:

1. The CSS files are dynamically injected by JavaScript. However, only CSS files that are **directly inlined** into the `<head`> of the initial HTML file "block rendering" - meaning that rendering is delayed until those style sheets are loaded. See [here](https://github.com/chrishtr/rendering/blob/master/stylesheet-loading-behavior.md) if you'd like to know all the details of how this works in browsers.

2. The loader script dynamically modifies the HTML to insert a fixed set of widgets, and manually overrides certain CSS.

3. The header element has a dependency on a web font which may not exist or take time to download.

This PR removes all of these issues by:
- Inlining CSS
- Inllning the widget HTML
- Adding CSS adjustments to CSS.
